### PR TITLE
fix: wire publishProfile correctly and drop dropped is_published colu…

### DIFF
--- a/shub/src/features/profiles/components/WorkerProfileManagement.tsx
+++ b/shub/src/features/profiles/components/WorkerProfileManagement.tsx
@@ -29,7 +29,7 @@ const WorkerProfileManagement: React.FC<WorkerProfileManagementProps> = ({ onBac
   const [displayNameInput, setDisplayNameInput] = useState<string | null>(null);
   const [displayNameSaving, setDisplayNameSaving] = useState(false);
   const [wizardDismissed, setWizardDismissed] = useState(false);
-  const { profile, loading, error, updateProfile, saving } = useWorkerProfile(userId);
+  const { profile, loading, error, updateProfile, publishProfile, saving } = useWorkerProfile(userId);
   const { services, loading: servicesLoading } = useServices();
   const { userProfile: authProfile, setUserProfile } = useAuthStore();
 
@@ -118,7 +118,7 @@ const WorkerProfileManagement: React.FC<WorkerProfileManagementProps> = ({ onBac
     }
 
     try {
-      await updateProfile({ isPublished: true });
+      await publishProfile();
       // Keep the auth store in sync so DashboardPage stops redirecting to profile setup
       if (authProfile) {
         setUserProfile({ ...authProfile, isPublished: true });

--- a/shub/src/features/profiles/hooks/useWorkerProfile.ts
+++ b/shub/src/features/profiles/hooks/useWorkerProfile.ts
@@ -224,13 +224,12 @@ export const useWorkerProfile = (userId: string | undefined) => {
     setError(null);
 
     try {
-      const [wpResult, userResult] = await Promise.all([
-        supabase.from('worker_profiles').update({ published: true }).eq('user_id', userId),
-        supabase.from('users').update({ is_published: true }).eq('id', userId),
-      ]);
+      const { error: wpError } = await supabase
+        .from('worker_profiles')
+        .update({ published: true })
+        .eq('user_id', userId);
 
-      if (wpResult.error) throw wpResult.error;
-      if (userResult.error) throw userResult.error;
+      if (wpError) throw wpError;
 
       setProfile(prev => prev ? { ...prev, isPublished: true } : prev);
     } catch (err: any) {


### PR DESCRIPTION
…mn update

Two bugs preventing published profiles from appearing in browse/guest view:

1. handlePublishProfile was calling updateProfile({ isPublished: true }) which has no mapping to any DB column — nothing was written to the database. Fixed to call publishProfile() which sets worker_profiles.published = true.

2. publishProfile was also trying to set users.is_published = true, but that column was dropped in drop_bridging_columns. Removed the users update; worker_profiles.published is the sole source of truth for visibility.

https://claude.ai/code/session_01Gx2Hw1NsCD8cTmC1CB2JYN