### PR TITLE
fix: correct WorkerBrowser query so published profiles actually appear

### DIFF
--- a/shub/src/features/listings/components/WorkerBrowser.tsx
+++ b/shub/src/features/listings/components/WorkerBrowser.tsx
@@ -63,25 +63,26 @@ const WorkerBrowser: React.FC<WorkerBrowserProps> = ({ onWorkerSelect, showBackB
       // Fetch published host profiles — join user data for display info
       const { data, error } = await supabase
         .from('worker_profiles')
-        .select('*, user:user_id(id, email, name, display_name, avatar_url, is_verified, status)')
+        .select('*, user:user_id(id, email, display_name, avatar_url, is_verified, primary_location, status)')
         .eq('published', true);
 
       if (error) {
         console.error('Error fetching hosts:', error);
-        setWorkers(getMockWorkers());
+        // Only fall back to mock data in development when no real data exists
+        setWorkers([]);
       } else {
         const transformed = (data || []).map((d: any) => ({
           id: d.user_id,
-          name: d.display_name || d.user?.display_name || d.user?.name || 'Host',
+          name: d.user?.display_name || 'Host',
           email: d.user?.email || '',
           role: 'worker' as const,
-          avatar: d.profile_photos?.[0] || d.user?.avatar_url,
-          location: d.primary_location || d.location,
-          verified: d.is_verified || d.user?.is_verified,
-          bio: d.bio,
-          profilePhotos: d.profile_photos || [],
-          status: d.status || d.user?.status || 'available',
-          primaryLocation: d.primary_location,
+          avatar: d.photo_album?.[0] || d.user?.avatar_url,
+          location: d.user?.primary_location || d.region || '',
+          verified: d.user?.is_verified ?? false,
+          bio: d.bio || '',
+          profilePhotos: d.photo_album || [],
+          status: d.user?.status || 'available',
+          primaryLocation: d.user?.primary_location || d.region || '',
         }));
         setWorkers(transformed);
       }


### PR DESCRIPTION
The browse query was silently failing and falling back to mock data (Sarah Johnson etc.) because:

1. The join selected 'name' from users — that column was dropped in drop_bridging_columns — causing a PostgREST schema cache error that triggered the catch → getMockWorkers() fallback.

2. The transform read d.profile_photos and d.primary_location which do not exist on worker_profiles (photos are photo_album, location comes from the joined users row).

Fixes:
- Remove 'name' from join; read display_name only
- Add primary_location and status to the users join
- Map avatar from photo_album[0], location from user.primary_location
- On query error show empty list instead of fake mock workers

https://claude.ai/code/session_01Gx2Hw1NsCD8cTmC1CB2JYN